### PR TITLE
Add recommendation for password expiration

### DIFF
--- a/wpc/conf.py
+++ b/wpc/conf.py
@@ -4367,7 +4367,7 @@ NB: This issue has only been reported for NTFS filesystems.  Other non-NTFS file
        'confidence': 5,
        'title': "Some Users Have Passwords That Don't Expire",
        'description': '''TODO UF_DONT_EXPIRE_PASSWD was set for some accounts that were neither locked nor disabled''',
-       'recommendation': '''TODO''',
+       'recommendation': '''Users should not be forced to change passwords as per NIST Special Publication 800-63B: "Do not require that memorized secrets be changed arbitrarily (e.g., periodically) unless there is a user request or evidence of authenticator compromise." (published 2017, last updated in 2020). Various studies show that this reduces password quality, as summarized by Microsoft Research in "Password Guidance" (Robyn Hicock, May 2016). If your organisation has different rules that supercede best current practice, however, non-expiring passwords may be a violation of policy.''',
        'supporting_data': {
           'username': {
              'section': "description",


### PR DESCRIPTION
As written in the recommendation, it has long not been best current practice anymore to force password changes upon users. Sources (as also referenced in the recommendation):

- https://pages.nist.gov/800-63-3/sp800-63b.html
- https://www.microsoft.com/en-us/research/publication/password-guidance/ (see page 9, it links to research from University College London, University of North Carolina, and Carleton University via the FTC link)

My thoughts on the matter are:

- The warning "there are users without expiring passwords" should just not be shown in general because it's not a warning: it's a good thing.
- However, many people still don't know this (both inside and especially outside the security field). It might be better to make people aware of updated research (for decades, "change your passwords" has been repeated and recommended, and many people know of the "change your password" day even if they don't do it).
- Some organisations might *want* to see this warning because they have a policy diverging from the latest recommendations, so that's another reason to potentially leave this in (even if it seems misguided to me).

I'm fine just getting rid of WPC112 altogether if that's the course you prefer to steer, but recognizing that removal of a warning likely creates debate and that there are also reasons to keep it, adding pointers to research seems more practically useful.